### PR TITLE
Use 'period' class to store trip length and soak time

### DIFF
--- a/R/01-data-interviews.R
+++ b/R/01-data-interviews.R
@@ -58,7 +58,7 @@ prepare_interviews = function(input_file, src_name = NULL, include_whitefishes =
   }
 
   # calculate trip duration
-  dat_out$trip_duration = lubridate::as.duration(lubridate::interval(dat_out$trip_start, dat_out$trip_end))
+  dat_out$trip_duration = lubridate::as.period(lubridate::interval(dat_out$trip_start, dat_out$trip_end))
 
   ### STEP X: handle soak times
   # extract the soak time variable name and time unit names from raw data
@@ -70,11 +70,10 @@ prepare_interviews = function(input_file, src_name = NULL, include_whitefishes =
 
   # convert to duration class: different function depending on the units and format of the input
   if (soak_units_entered == "hrs" & soak_class == "character") {
-    dat_out$soak_duration = lubridate::as.duration(lubridate::hm(dat_in[,soak_var]))
+    dat_out$soak_duration = lubridate::as.period(round(lubridate::as.duration(lubridate::hm(dat_in[,soak_var]))))
   } else {
-    dat_out$soak_duration = lubridate::duration(num = dat_in[,soak_var], ifelse(soak_units_entered == "hrs", "hours", "minutes"))
+    dat_out$soak_duration = lubridate::as.period(round(lubridate::duration(num = dat_in[,soak_var], ifelse(soak_units_entered == "hrs", "hours", "minutes"))))
   }
-  dat_out$soak_duration = round(dat_out$soak_duration)
 
   ### STEP X: handle which species to keep
   keep_spp = c("chinook", "chum", "sockeye")


### PR DESCRIPTION
No associated issue to reference, given this was a small change it wasn't worth creating a whole issue about. See below for context.

The column names are the same, but the printing of the total trip time and total soak time in the data frame is much cleaner for "period" class than for the "duration" class (which counts seconds elapsed). We can still do all of the same math and logic on period classes as duration classes, the only thing this changes is how they look in the data frame. For example, before this change, these "time elapsed" variables looked like:

```
[1] "21600s (~6 hours)"     "36120s (~10.03 hours)" "30960s (~8.6 hours)"   "40620s (~11.28 hours)" "36720s (~10.2 hours)" 
[6] "4740s (~1.32 hours)"
```

when stored as duration class, now as period class, they look like:

```
[1] "6H 0M 0S"   "10H 2M 0S"  "8H 36M 0S"  "11H 17M 0S" "10H 12M 0S" "1H 19M 0S" 
```

which is more compact and easier to read.
