### PR TITLE
Build the basics of a project template

### DIFF
--- a/R/project-skeleton.R
+++ b/R/project-skeleton.R
@@ -1,0 +1,15 @@
+
+KuskoHarvest_skeleton = function(path, set_only) {
+
+  # create the package directory
+  dir.create(path, recursive = TRUE, showWarnings = FALSE)
+
+  # create a settings file
+  settings_filename = file.path(path, "settings.txt")
+  writeLines(paste("set_only:", set_only), settings_filename)
+
+  # create subdirectories
+  dir.create(file.path(path, "data"))
+
+  TRUE
+}

--- a/inst/rstudio/templates/project/skeleton.dcf
+++ b/inst/rstudio/templates/project/skeleton.dcf
@@ -1,0 +1,9 @@
+Title: Harvest Estimation using KuskoHarvEst
+Caption: Name your project 'KuskoHarvEst_YYYY_MM_DD'
+Binding: KuskoHarvest_skeleton
+
+Parameter: set_only
+Widget: CheckboxInput
+Label: Opportunity Allowed Set Nets Only?
+Default: Off
+Position: Left


### PR DESCRIPTION
This PR addresses #49 and introduces the first point-and-click aspect of the workflow.

The user still needs to open RStudio, but once they have 'KuskoHarvEst' installed, they will be able to create a new harvest estimate project through built-in menus. This will generate a template directory for the user to place the data files in and to execute all subsequent tasks. This will be the location where all output is generated and saved to as well.

Merging this PR will close #49.