### PR TITLE
Improve histograms

### DIFF
--- a/R/03-out-histograms.R
+++ b/R/03-out-histograms.R
@@ -79,7 +79,7 @@ make_one_histogram = function(interview_data, gear, variable, n_bins = 10) {
   hist(x, breaks = breaks, ylim = c(0, max(bin_counts)) * 1.4, main = main, xlab = "Value", ylab = "Frequency",
        col = "grey70", border = "white", xaxt = "n", yaxt = "n")
   axis(side = 1); axis(side = 2, las = 2)
-  legend("top", x.intersp = 0, ncol = 2, legend = means_text, bty = "n", cex = 1)
+  legend("topleft", x.intersp = -0.5, ncol = 2, legend = means_text, bty = "n", cex = 1.15)
   usr = par("usr")
   segments(usr[1], usr[3], usr[2], usr[3], xpd = T)
 }

--- a/inst/rstudio/templates/project/resources/02-estimate-report/06a-histograms_drift.Rmd
+++ b/inst/rstudio/templates/project/resources/02-estimate-report/06a-histograms_drift.Rmd
@@ -1,4 +1,4 @@
 
-```{r histograms, fig.width = 7.5, fig.height = 4.5, fig.cap = make_histogram_caption(interview_data, "drift")}
+```{r histograms, fig.width = 7.5, fig.height = 4, fig.cap = make_histogram_caption(interview_data, "drift")}
 make_all_histograms(interview_data, "drift", c("total_salmon", "chinook", "chum+sockeye", "trip_duration", "soak_duration", "p_chinook"))
 ```

--- a/inst/rstudio/templates/project/resources/02-estimate-report/06b-histograms_set.Rmd
+++ b/inst/rstudio/templates/project/resources/02-estimate-report/06b-histograms_set.Rmd
@@ -1,4 +1,4 @@
 
-```{r histograms, fig.width = 7.5, fig.height = 4.5, fig.cap = make_histogram_caption(interview_data, "set")}
+```{r histograms, fig.width = 7.5, fig.height = 4, fig.cap = make_histogram_caption(interview_data, "set")}
 make_all_histograms(interview_data, "set", c("total_salmon", "chinook", "chum+sockeye", "trip_duration", "soak_duration", "p_chinook"))
 ```


### PR DESCRIPTION
This PR addresses #108 and improves histograms in two ways:

* Legend text is larger and easier to read than before
* The figure height is smaller (4 inches vs. 4.5 previously) - this should ensure that the histogram will fit on the second page and not be spilled onto a third

Merging this PR will close #108 