### PR TITLE
Misc data prep changes

### DIFF
--- a/R/01-data-flights.R
+++ b/R/01-data-flights.R
@@ -21,16 +21,16 @@ prepare_flights = function(input_file) {
   dat_out$end_time = combine_datetime(dat_in$date, dat_in$end)
   dat_out = cbind(dat_out, dat_in[,colnames(dat_in)[-which(colnames(dat_in) %in% c("date", "start", "end", "flight"))]])
 
-  ### STEP 2: make one row per flight
+  ### STEP 2: ensure gear is formatted properly
+  dat_out$gear = stringr::str_remove(tolower(dat_out$gear), " ")
+  dat_out$gear = stringr::str_remove(dat_out$gear, "net")
+
+  ### STEP 3: make one row per flight
   # reformat count data: make long
   dat_out = reshape2::melt(dat_out, id.vars = c("flight", "start_time", "end_time", "gear"), variable.name = "stratum", value.name = "count")
 
   # reformat count data: make wide
   dat_out = reshape2::dcast(dat_out, flight + start_time + end_time ~ stratum + gear, value.var = "count")
-
-  # ensure gear is formatted properly
-  dat_out$gear = stringr::str_remove(tolower(dat_out$gear), " ")
-  dat_out$gear = stringr::str_remove(dat_out$gear, "net")
 
   # return the formatted output
   return(dat_out)

--- a/R/01-data-flights.R
+++ b/R/01-data-flights.R
@@ -9,7 +9,7 @@
 prepare_flights = function(input_file) {
 
   ### STEP 0: read in data file
-  dat_in = read.csv(input_file, stringsAsFactors = FALSE)
+  dat_in = suppressWarnings(read.csv(input_file, stringsAsFactors = FALSE))
 
   ### STEP 1: handle dates/times
   dat_out = data.frame(flight = dat_in$flight)

--- a/R/01-data-flights.R
+++ b/R/01-data-flights.R
@@ -11,6 +11,10 @@ prepare_flights = function(input_file) {
   ### STEP 0: read in data file
   dat_in = suppressWarnings(read.csv(input_file, stringsAsFactors = FALSE))
 
+  # determine and delete the rows that have all NA values: Excel/CSV quirk sometimes includes these
+  all_NA = sapply(1:nrow(dat_in), function(i) all(is.na(dat_in[i,]) | dat_in[i,] == ""))
+  dat_in = dat_in[!all_NA,]
+
   ### STEP 1: handle dates/times
   dat_out = data.frame(flight = dat_in$flight)
   dat_out$start_time = combine_datetime(dat_in$date, dat_in$start)
@@ -23,6 +27,10 @@ prepare_flights = function(input_file) {
 
   # reformat count data: make wide
   dat_out = reshape2::dcast(dat_out, flight + start_time + end_time ~ stratum + gear, value.var = "count")
+
+  # ensure gear is formatted properly
+  dat_out$gear = stringr::str_remove(tolower(dat_out$gear), " ")
+  dat_out$gear = stringr::str_remove(dat_out$gear, "net")
 
   # return the formatted output
   return(dat_out)

--- a/R/01-data-interviews-one.R
+++ b/R/01-data-interviews-one.R
@@ -11,7 +11,7 @@
 prepare_interviews_one = function(input_file, include_village = FALSE, include_goals = FALSE) {
 
   ### STEP 0: load the input data file & format column names
-  dat_in = read.csv(input_file, stringsAsFactors = FALSE)
+  dat_in = suppressWarnings(read.csv(input_file, stringsAsFactors = FALSE))
 
   # determine and delete the rows that have all NA values: Excel/CSV quirk sometimes includes these
   all_NA = sapply(1:nrow(dat_in), function(i) all(is.na(dat_in[i,]) | dat_in[i,] == ""))

--- a/R/01-data-interviews-one.R
+++ b/R/01-data-interviews-one.R
@@ -32,15 +32,15 @@ prepare_interviews_one = function(input_file, include_village = FALSE, include_g
   dat_out = data.frame(source = rep(src_name, nrow(dat_in)))
 
   ### STEP 2: handle the stratum name
-  dat_out$stratum = dat_in$stratum
+  dat_out$stratum = stringr::str_remove(toupper(dat_in$stratum), " ")
 
   ### STEP 3: handle the gear (net) type
-  gear_entered = dat_in$gear
+  gear_entered = stringr::str_remove(dat_in$gear, " ")
   gear_standard = tolower(gear_entered) # make lowercase
   gear_standard = stringr::str_remove(gear_standard, "net")
   dat_out$gear = gear_standard
 
-  ### STEX 4: handle net dimensions
+  ### STEP 4: handle net dimensions
   has_mesh = "mesh" %in% vars
   dat_out$net_length = dat_in$length
   if (has_mesh) {

--- a/R/01-data-interviews-one.R
+++ b/R/01-data-interviews-one.R
@@ -34,6 +34,14 @@ prepare_interviews_one = function(input_file, include_village = FALSE, include_g
   ### STEP 2: handle the stratum name
   dat_out$stratum = stringr::str_remove(toupper(dat_in$stratum), " ")
 
+  # determine if any records have an unknown stratum (e.g., O). If so, remove them and return warning
+  unknown_stratum = !(dat_out$stratum %in% c(strata_names$stratum, NA))
+  if (any(unknown_stratum)) {
+    warning("There were ", sum(unknown_stratum), " records with invalid stratum values: ", paste(unique(dat_out$stratum[unknown_stratum]), collapse = ", "), "\n  They have been discarded.")
+    dat_in = dat_in[!unknown_stratum,]
+    dat_out = dat_out[!unknown_stratum,]
+  }
+
   ### STEP 3: handle the gear (net) type
   gear_entered = stringr::str_remove(dat_in$gear, " ")
   gear_standard = tolower(gear_entered) # make lowercase


### PR DESCRIPTION
This PR introduces several small changes that address #117, #126, #127, and #128. All changes seek to enforce consistency in data preparation to prevent small data entry issues from crashing the program. It does things like:

* Removes empty rows in raw CSV files -- these will be all NA in R if not handled properly
* Ensures all strata are recognized as A, B, C, or D1
* Ensures all gear and strata names to not have spaces, even if they are entered with spaces -- this came up repeatedly in 2021

Merging this PR will:

* Close #117
* Close #126 
* Close #127 
* Close #128 
