### PR TITLE
Update set net effort estimator

### DIFF
--- a/R/02-est-stratify-effort.R
+++ b/R/02-est-stratify-effort.R
@@ -19,7 +19,7 @@ stratify_effort = function(flight_data, gear, effort_est) {
   ave_p_stratum = unname(colMeans(p_stratum))
 
   # STEP 4: multiply this by the total effort estimate
-  stratified_effort_est = round(effort_est * ave_p_stratum)
+  stratified_effort_est = ceiling(effort_est * ave_p_stratum)
 
   # STEP 5: give the elements nice names for the stratum
   stratum_names = colnames(flight_counts)

--- a/man/estimate_effort.Rd
+++ b/man/estimate_effort.Rd
@@ -20,7 +20,7 @@ estimate_effort(interview_data, flight_data, gear, method = "dbl_exp")
 \item{method}{Character; which effort estimator should be applied? Only two options are accepted:
 \itemize{
 \item \code{method = "dbl_exp"} to perform corrections for trips counted on consecutive flights and trips not counted at all - generally used for drift nets
-\item \code{method = "max_per_stratum"} to perform a simple calculation of the maximum number of trips counted in a given stratum - generally used for set nets
+\item \code{method = "max_per_stratum"} to perform a simple calculation of the maximum number of trips counted in a given stratum - generally used for set nets. If this method is used, a further constraint is added to force the total effort estimate to be at least as large as the total number of interviews for that gear type.
 }}
 }
 \description{


### PR DESCRIPTION
Really, this is the `"max_per_stratum"` estimator, but it is really only ever used on set nets. 

This PR addresses #123 and imposes a new constraint on this estimator. Sometimes, there will be more set net interviews than the total set net effort estimate, which doesn't make sense. It must be an indication of missed, short set net trips that occur between flights, or due to non-detection from the airplane. Either way, this new constraint forces the effort estimate when using the `"max_per_stratum"` option to be at least as large as the number of interviews available for the gear type in question.

**An additional change was made:** when apportioning the total effort estimate to strata (`stratify_effort()`), there is rounding involved. The rounding rule has been updated to always round up. This will prevent fractional effort from being rounded to no effect (e.g., 0.25), and should prevent cases where strata-specific effort estimates are lower than the number of strata-specific interviews. This change impacts both effort estimation methods. 

Merging this PR will close #123.