### PR TITLE
Delete trip start/stop time appendix tables

### DIFF
--- a/inst/rstudio/templates/project/resources/02-estimate-report/08a-appendix_drift.Rmd
+++ b/inst/rstudio/templates/project/resources/02-estimate-report/08a-appendix_drift.Rmd
@@ -46,11 +46,3 @@ make_appendix_table(interview_data, "drift", "soak_duration")
 ```{r trip-duration-appendix-table}
 make_appendix_table(interview_data, "drift", "trip_duration")
 ```
-
-```{r trip-start-appendix-table}
-make_appendix_table(interview_data, "drift", "trip_start")
-```
-
-```{r trip-end-appendix-table}
-make_appendix_table(interview_data, "drift", "trip_end")
-```

--- a/inst/rstudio/templates/project/resources/02-estimate-report/08b-appendix_set.Rmd
+++ b/inst/rstudio/templates/project/resources/02-estimate-report/08b-appendix_set.Rmd
@@ -46,11 +46,3 @@ make_appendix_table(interview_data, "set", "soak_duration")
 ```{r trip-duration-appendix-table}
 make_appendix_table(interview_data, "set", "trip_duration")
 ```
-
-```{r trip-start-appendix-table}
-make_appendix_table(interview_data, "set", "trip_start")
-```
-
-```{r trip-end-appendix-table}
-make_appendix_table(interview_data, "set", "trip_end")
-```


### PR DESCRIPTION
This PR addresses #130 and removes two tables from the appendix that take up a lot of space but are not really that useful: the trip start and end time summaries across geographic strata.

These tables would sometimes result in the appendix taking 3 pages instead of just two (leading to a 3 page front/back total document where it could be just two pages front/back). They are not very useful, and so they have been deleted, which further completes #118. Note that they can easily be added back in if needed/desired at some point in the future, i.e., `make_appendix_table()` still includes the option to generate this output.

Merging this PR will close #130. 