### PR TITLE
Improve data prep notes

### DIFF
--- a/R/01-data-interviews.R
+++ b/R/01-data-interviews.R
@@ -24,12 +24,6 @@ prepare_interviews = function(input_files, ...) {
     stop ("More than one unique start date was found in the interview data:\n(", paste(start_dates, collapse = "; "), ")\nYou must edit the raw data to ensure all interviews are from trips that started on the same day.")
   }
 
-  # perform suitability checks and combine logical flags with the data
-  tasks = c("effort", "catch_rate_info", "catch_rate_info_reliable", "avg_soak", "avg_net_length")
-  suitable = sapply(tasks, suitable_for, interview_data = interview_data)
-  colnames(suitable) = paste0("suit_", c("effort", "cr_info", "cr_reliable", "avg_soak", "avg_net"))
-  interview_data = cbind(interview_data, suitable)
-
   # discard any trips lacking gear type information
   # if the interview is lacking gear, it is totally useless.
   # trip times can't be used for effort estimation b/c gear uncertainty
@@ -39,6 +33,12 @@ prepare_interviews = function(input_files, ...) {
     interview_data = interview_data[-which(no_gear),]
     warning("\n", sum(no_gear), " interview(s) had missing gear type information.\nThese records have been discarded since they\ncannot be used for anything.")
   }
+
+  # perform suitability checks and combine logical flags with the data
+  tasks = c("effort", "catch_rate_info", "catch_rate_info_reliable", "avg_soak", "avg_net_length")
+  suitable = sapply(tasks, suitable_for, interview_data = interview_data)
+  colnames(suitable) = paste0("suit_", c("effort", "cr_info", "cr_reliable", "avg_soak", "avg_net"))
+  interview_data = cbind(interview_data, suitable)
 
   # create empty note objects
   impossible_trip_notes = rep(NA, nrow(interview_data))

--- a/R/01-data-interviews.R
+++ b/R/01-data-interviews.R
@@ -40,7 +40,10 @@ prepare_interviews = function(input_files, ...) {
   colnames(suitable) = paste0("suit_", c("effort", "cr_info", "cr_reliable", "avg_soak", "avg_net"))
   interview_data = cbind(interview_data, suitable)
 
-  # create empty note objects
+  # extract notes on suitability
+  suitability_notes = suitable_for(interview_data, task = "notes")
+
+  # create empty note objects for checks performed within this function
   impossible_trip_notes = rep(NA, nrow(interview_data))
   impossible_soak_notes = rep(NA, nrow(interview_data))
   outlier_cpt_notes = rep(NA, nrow(interview_data))
@@ -76,7 +79,10 @@ prepare_interviews = function(input_files, ...) {
   }
 
   # combine the notes from each record
-  notes = paste(impossible_trip_notes, impossible_soak_notes, outlier_cpt_notes, sep = "; ")
+  notes = sapply(1:nrow(interview_data), function(i) {
+    paste(suitability_notes[i], impossible_trip_notes[i], impossible_soak_notes[i], outlier_cpt_notes[i], sep = "; ")
+  })
+  notes = stringr::str_remove_all(notes, "NA; ")
   notes = stringr::str_remove_all(notes, "NA")
   notes = stringr::str_remove_all(notes, "; $")
   notes = stringr::str_remove_all(notes, "^; ")

--- a/R/01-data-interviews.R
+++ b/R/01-data-interviews.R
@@ -63,7 +63,7 @@ prepare_interviews = function(input_files, ...) {
   # if any are found, change the soak time to be the same as the trip duration, and include a note
   impossible_soaks = !is_possible_soak(interview_data)
   if (any(impossible_soaks)) {
-    impossible_soak_notes[impossible_soaks] = paste0("Impossible soak duration (", interview_data[impossible_soaks,"soak_duration"], ") edited to trip duration")
+    impossible_soak_notes[impossible_soaks] = paste0("Long soak duration (", interview_data[impossible_soaks,"soak_duration"], ") edited to trip duration (", interview_data[impossible_soaks,"trip_duration"], ")")
     interview_data$soak_duration[impossible_soaks] = interview_data$trip_duration[impossible_soaks]
     warning("\n", sum(impossible_soaks), " interview(s) had soak duration reported longer than trip duration.\nFor these records, the soak duration has been set to the trip duration,\nand a note has been included in the output.")
   }
@@ -71,7 +71,7 @@ prepare_interviews = function(input_files, ...) {
   # perform checks for if the average catch per trip is an outlier
   cpt_outliers = is_catch_per_trip_outlier(interview_data)
   if (any(cpt_outliers)) {
-    outlier_cpt_notes[cpt_outliers] = "Interview has a large influence on the average catch per trip, its catch rate info, soak time, and net length have been deemed unsuitable"
+    outlier_cpt_notes[cpt_outliers] = "Catch per trip highly influential, catch rate rate, soak time, and net length deemed unsuitable for average"
     interview_data$suit_cr_reliable[cpt_outliers] = FALSE
     interview_data$suit_avg_soak[cpt_outliers] = FALSE
     interview_data$suit_avg_net[cpt_outliers] = FALSE

--- a/R/01-data-suitable-for.R
+++ b/R/01-data-suitable-for.R
@@ -17,7 +17,7 @@
 #'   * `"avg_net_length"`: Checks if the net length is of a normal length
 #'   * `"notes"`: Returns noteworthy check failures
 #' @return If `task != "notes"`, a logical vector with one element corresponding to each interview record will be returned (`TRUE` indicates suitability).
-#'   If `task == "notes"`, a character vector with each element storing a comma-separated list of noteworthy check failures for each record will be returned.
+#'   If `task == "notes"`, a character vector with each element storing a semi-colon-separated list of noteworthy check failures for each record will be returned.
 
 suitable_for = function(interview_data, task) {
 
@@ -42,6 +42,7 @@ suitable_for = function(interview_data, task) {
     # discard empties
     notes = stringr::str_remove_all(notes, "NA; ")
     notes = stringr::str_remove_all(notes, "NA")
+    notes = stringr::str_remove_all(notes, "; $")
 
     # rename object for returning
     suitable = notes

--- a/R/01-data-suitable-for.R
+++ b/R/01-data-suitable-for.R
@@ -15,22 +15,47 @@
 #'   * `"catch_rate_reliable"`: Checks if catch rate data is reliable; must be: a not very short incomplete trip, not a soak outlier, and not a abnormally long net
 #'   * `"avg_soak"`: Checks if soak time is available, that it is a completed trip, and that it is not a soak outlier
 #'   * `"avg_net_length"`: Checks if the net length is of a normal length
-#'
+#'   * `"notes"`: Returns noteworthy check failures
+#' @return If `task != "notes"`, a logical vector with one element corresponding to each interview record will be returned (`TRUE` indicates suitability).
+#'   If `task == "notes"`, a character vector with each element storing a comma-separated list of noteworthy check failures for each record will be returned.
 
 suitable_for = function(interview_data, task) {
 
-  accepted_tasks = c("effort", "catch_rate_info", "catch_rate_info_reliable", "avg_soak", "avg_net_length")
+  accepted_tasks = c("effort", "catch_rate_info", "catch_rate_info_reliable", "avg_soak", "avg_net_length", "notes")
   if (!(task %in% accepted_tasks)) stop ("task must be one of: ", paste(paste0("'", accepted_tasks, "'"), collapse = ", "))
 
-  # to be useful for effort estimation (method = "dbl_exp"), it must have gear, trip times, and be a complete trip
+  if (task == "notes") {
+    # perform all checks and make a note for each if it violates criteria
+    note_trip_times = ifelse(!has_trip_times(interview_data), "Missing trip time", NA)
+    note_complete_trip = ifelse(!is_complete_trip(interview_data), "Incomplete trip", NA)
+    note_short_incomplete_trip = ifelse(is_short_incomplete_soak(interview_data), "Soak shorter than shortest complete trip", NA)
+    note_soak_time = ifelse(!has_soak(interview_data), "Missing soak time", NA)
+    note_net_length = ifelse(!has_net_length(interview_data), "Missing net length", NA)
+    note_soak_outlier = ifelse(is_soak_outlier(interview_data), "Soak time deemed an outlier", NA)
+    note_normal_net = ifelse(!is_normal_net(interview_data), "Net length deemed unreliable (too long)", NA)
+
+    # combine all check-specific notes into one string per record
+    notes = sapply(1:nrow(interview_data), function(i) {
+      paste(note_trip_times[i], note_complete_trip[i], note_short_incomplete_trip[i], note_soak_time[i], note_net_length[i], note_soak_outlier[i], note_normal_net[i], sep = "; ")
+    })
+
+    # discard empties
+    notes = stringr::str_remove_all(notes, "NA; ")
+    notes = stringr::str_remove_all(notes, "NA")
+
+    # rename object for returning
+    suitable = notes
+  }
+
+  # to be useful for effort estimation (method = "dbl_exp"), it must have trip times and be a complete trip
   if (task == "effort") {
-    suitable = has_gear(interview_data) & has_trip_times(interview_data) & is_complete_trip(interview_data)
+    suitable = has_trip_times(interview_data) & is_complete_trip(interview_data)
   }
 
   # does the interview have the sufficient data to calculate a catch rate?
   # this is regardless of the potential "reliability" of the information
   if (task == "catch_rate_info") {
-    suitable = has_gear(interview_data) & has_soak(interview_data) & has_net_length(interview_data)
+    suitable = has_soak(interview_data) & has_net_length(interview_data)
   }
 
   # does the interview have information that is not out of the ordinary, or otherwise deemed to

--- a/man/suitable_for.Rd
+++ b/man/suitable_for.Rd
@@ -18,6 +18,10 @@ suitable_for(interview_data, task)
 \item \code{task = "avg_net_length"}
 }}
 }
+\value{
+If \code{task != "notes"}, a logical vector with one element corresponding to each interview record will be returned (\code{TRUE} indicates suitability).
+If \code{task == "notes"}, a character vector with each element storing a comma-separated list of noteworthy check failures for each record will be returned.
+}
 \description{
 A wrapper around a variety of data checking functions.
 }
@@ -29,5 +33,6 @@ The checks for each task include:
 \item \code{"catch_rate_reliable"}: Checks if catch rate data is reliable; must be: a not very short incomplete trip, not a soak outlier, and not a abnormally long net
 \item \code{"avg_soak"}: Checks if soak time is available, that it is a completed trip, and that it is not a soak outlier
 \item \code{"avg_net_length"}: Checks if the net length is of a normal length
+\item \code{"notes"}: Returns noteworthy check failures
 }
 }

--- a/man/suitable_for.Rd
+++ b/man/suitable_for.Rd
@@ -20,7 +20,7 @@ suitable_for(interview_data, task)
 }
 \value{
 If \code{task != "notes"}, a logical vector with one element corresponding to each interview record will be returned (\code{TRUE} indicates suitability).
-If \code{task == "notes"}, a character vector with each element storing a comma-separated list of noteworthy check failures for each record will be returned.
+If \code{task == "notes"}, a character vector with each element storing a semi-colon-separated list of noteworthy check failures for each record will be returned.
 }
 \description{
 A wrapper around a variety of data checking functions.


### PR DESCRIPTION
This PR addresses #137 to improve the notes field of the processed interview data set.

I was never quite satisfied with the old notes handler. Basically, it returned notes in one of three cases:

* If trip times were impossible, notified user to check the raw data and that they would be set to NA
* If soak time was edited to be equal to the trip time
* If the average catch per trip was highly influenced by an interview, that its key catch rate info would be set to NA

But there are several other cases where a record is deemed unsuitable for a purpose, but the user may want to know why. An example is the catch rate info suitability: it could be because either the soak time is an outlier or because the net length was too long. Information to determine which triggered the decision is not included in the notes column of the output of `prepare_interviews()`.

Merging this PR will close #137.