### PR TITLE
Use yaml package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,5 @@ Imports:
     knitr,
     kableExtra,
     tinytex,
-    latex2exp
+    latex2exp,
+    yaml


### PR DESCRIPTION
This PR addresses #139 and uses the '[yaml](https://github.com/viking/r-yaml/)' R package to more cleanly construct the YAML header of the automatically generated Rmarkdown documents. The old version created a bunch of objects, each one a character string that specified the correct setting for each YAML setting, then pasted them together into one string. The 'yaml' package has the user specify these as list elements which are then passed to `yaml::as.yaml` to render a nice YAML string. This is the whole purpose of the 'yaml' package, and the code is much cleaner (and easier to edit!) this way.

Merging this PR will close #139.