### PR TITLE
Add a date argument to report()

### DIFF
--- a/R/03-out-report.R
+++ b/R/03-out-report.R
@@ -12,6 +12,9 @@
 #' @param stratum Character; the geographic stratum to summarize.
 #'   Accepted options are `"A"`, `"B"`, `"C"`, `"D1"`, or `"total"`.
 #'   Defaults to `"total"`.
+#' @param date Character; the date to summarize.
+#'   Should be supplied in YYYY-MM-DD format if not `NULL`.
+#'   Defaults to `NULL`, in which case the date is ignored when summarizing.
 #' @param CI Logical; should the confidence intervals be returned?
 #' @param conf_level Numeric; the confidence level of the confidence interval.
 #'   E.g., `0.95` corresponds to a 95% confidence interval (the default).
@@ -24,7 +27,7 @@
 #' @export
 #'
 
-report = function(spp = "total", gear = "total", stratum = "total", CI = TRUE, conf_level = 0.95, digits = -1, return_numeric = FALSE, boot_out_use = NULL) {
+report = function(spp = "total", gear = "total", stratum = "total", date = NULL, CI = TRUE, conf_level = 0.95, digits = -1, return_numeric = FALSE, boot_out_use = NULL) {
 
   # error handle
   if (is.null(boot_out_use)) {
@@ -33,6 +36,11 @@ report = function(spp = "total", gear = "total", stratum = "total", CI = TRUE, c
     } else {
       boot_out_use = boot_out
     }
+  }
+
+  # select output from the requested date
+  if (!is.null(date)) {
+    boot_out_use = boot_out_use[boot_out_use$date == date,]
   }
 
   # convert to long form

--- a/man/report.Rd
+++ b/man/report.Rd
@@ -8,6 +8,7 @@ report(
   spp = "total",
   gear = "total",
   stratum = "total",
+  date = NULL,
   CI = TRUE,
   conf_level = 0.95,
   digits = -1,
@@ -27,6 +28,10 @@ Defaults to \code{"total"}.}
 \item{stratum}{Character; the geographic stratum to summarize.
 Accepted options are \code{"A"}, \code{"B"}, \code{"C"}, \code{"D1"}, or \code{"total"}.
 Defaults to \code{"total"}.}
+
+\item{date}{Character; the date to summarize.
+Should be supplied in YYYY-MM-DD format if not \code{NULL}.
+Defaults to \code{NULL}, in which case the date is ignored when summarizing.}
 
 \item{CI}{Logical; should the confidence intervals be returned?}
 


### PR DESCRIPTION
This PR closes #144. It adds `report(..., date = NULL)`. If `boot_out` contains multiple dates (e.g., for post-season processing), then one can run e.g., `report(..., date = "2021-06-12")` to obtain summaries for a particular date, gear, stratum, species, etc.

The default `date = NULL` setting will ignore the date column of `boot_out` when applying the summary functions, so all previous usages remain the same by leaving it as default. This is because all past usages have been when there is only one date in `boot_out`.