### PR TITLE
Add a shiny::stopApp() call after clicking "Save" on meta tool

### DIFF
--- a/R/05-tool-meta.R
+++ b/R/05-tool-meta.R
@@ -67,7 +67,7 @@ meta_tool = function() {
 
     # button to export the information to a .rds file
     miniUI::miniButtonBlock(
-      shiny::actionButton(inputId = "save_meta", label = "Save", icon = shiny::icon("save"), class = "btn-primary")
+      shiny::actionButton(inputId = "save_meta", label = "Save and Close", icon = shiny::icon("save"), class = "btn-primary")
     )
   )
 
@@ -105,11 +105,14 @@ meta_tool = function() {
 
       # export this list to an rds file to be used later
       saveRDS(meta, file.path(output_data_dir, paste0(file_date(meta$start_date), "_meta.rds")))
+
+      # close the app
+      shiny::stopApp()
     })
 
     # Handle the Done button being pressed
     shiny::observeEvent(input$done, {
-      stopApp()
+      shiny::stopApp()
     })
   }
 


### PR DESCRIPTION
This PR addresses #163 and introduces a nice feature where the "Save" button on the meta-data entry tool is now a "Save and Close" button. The user now just clicks this button to both save the output and close the tool at the same time. Prior to this, there may have been some question as to whether the tool did what it was suppose to do when the button was clicked.