### PR TITLE
Check data source source name

### DIFF
--- a/R/01-data-interviews-one.R
+++ b/R/01-data-interviews-one.R
@@ -29,8 +29,14 @@ prepare_interviews_one = function(input_file, include_village = FALSE, include_g
   colnames(dat_in) = vars
 
   ### STEP 1: handle the source name
-  src_name = stringr::str_extract(basename(input_file), "^[A-Z]+")
-  dat_out = data.frame(source = rep(src_name, nrow(dat_in)))
+  src_name = toupper(stringr::str_extract(basename(input_file), "^[A-Z]+"))
+
+  # if source name not recognized, return an error
+  if (!(src_name %in% rownames(source_names))) {
+    stop("The data source name (", src_name, ") was not recognized.\nAccepted values are: ", paste(rownames(source_names), collapse = ", "), ".\nPlease change the data file name to match one of these data sources,\nor notify the software developer if a new data source has been added.")
+  } else {
+    dat_out = data.frame(source = rep(src_name, nrow(dat_in)))
+  }
 
   ### STEP 2: handle the stratum name
   dat_out$stratum = stringr::str_remove(toupper(dat_in$stratum), " ")


### PR DESCRIPTION
This PR addresses #162. The software will now return an error if the source name in the interview data file is not recognized. That is, if the data file does not start with one of `ADFG`, `BBH`, `CBM`, `FC` or `LE` (or lower case versions of these), the program will stop with an informative error message. If new data sources become available in the future, the `source_names` object needs to be updated with the meta data for the data source (i.e., abbreviation, description, collecting organization).