### PR TITLE
Add smart_round to make_goal_summary_table()

### DIFF
--- a/R/03-out-report-tables.R
+++ b/R/03-out-report-tables.R
@@ -532,6 +532,7 @@ make_goals_summary_table = function(interview_data) {
 
   # format the counts as percentages
   counts$Freq = counts$Freq/n_goal_interviews
+  counts$Freq = smart_round(counts$Freq, digits = 2)
   counts$Freq = percentize(counts$Freq, escape = TRUE)
 
   # format the table


### PR DESCRIPTION
This PR addresses #166. When `smart_round()` was introduced in #159, I forgot to include its implementation in this table; this PR addresses this problem and ensures that the percentages in the goals summary table will always sum to 100%.