### PR TITLE
Fix spacing in PDF

### DIFF
--- a/inst/rstudio/templates/project/resources/01-common/report-template.tex
+++ b/inst/rstudio/templates/project/resources/01-common/report-template.tex
@@ -17,13 +17,13 @@
 % set page margins
 \usepackage[top=0.5in,right=0.75in,bottom=0.75in,left=0.75in]{geometry}
 
+% load setspace package
+\usepackage{setspace}
+
 % settings for hyperlinks
 \usepackage{hyperref}
 \hypersetup{unicode=true,pdfborder={0 0 0},breaklinks=true,colorlinks=true,urlcolor=blue}
 \urlstyle{same}  % don't use monospace font for urls
-
-% load setspace package
-\usepackage{setspace}
 
 % settings for figures. Not sure where this came from...
 \usepackage{graphicx,grffile}

--- a/inst/rstudio/templates/project/resources/01-common/report-template.tex
+++ b/inst/rstudio/templates/project/resources/01-common/report-template.tex
@@ -9,10 +9,8 @@
 \usepackage{amssymb,amsmath}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
-\IfFileExists{microtype.sty}{%
 \usepackage{microtype}
-\UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
-}{}
+\UseMicrotypeSet[protrusion]{basicmath}
 
 % set page margins
 \usepackage[top=0.5in,right=0.75in,bottom=0.75in,left=0.75in]{geometry}
@@ -62,7 +60,6 @@
 \usepackage[hang,flushmargin]{footmisc}
 
 % set up captions
-\usepackage{microtype}
 \usepackage[labelfont={bf,sc},labelsep=period,font=small,figureposition=bottom]{caption}
 \captionsetup{width=\textwidth,justification=raggedright,singlelinecheck=false}
 \usepackage{floatrow}

--- a/inst/rstudio/templates/project/resources/01-common/report-template.tex
+++ b/inst/rstudio/templates/project/resources/01-common/report-template.tex
@@ -109,7 +109,7 @@ $endif$
 \rule{\textwidth}{1pt}
 \begin{flushleft}
 
-{\bf\LARGE{$title$}}\\
+{\bf\LARGE{$title$}}\\[3pt]
 {\Large{$opener-label$}}\\
 
 {\small{Opportunity Time Period: $opener-start$ -- $opener-end$ ($opener-duration$)}}\\


### PR DESCRIPTION
Merging this PR will close:

* #183 
* #184 
* #185 

Actually, #185 was already a non-issue, since the 'parskip' package is already included in the list of $\mathrm{\TeX}$ packages that need to be installed via `tinytex::tlmgr_install()`. So users would not have experienced the problems described in #183 had they followed the installation instructions. I recently upgraded to R4.3.0 and did not run the install command following the instructions and apparently 'parskip' is not installed with TinyTex.

Nonetheless, this PR cleans up the pandoc template (`resource_path("01-common/report-template.tex")`) to remove the unnecessary `IfFileExists{` code for the 'parskip' and 'microtype' packages.

