### PR TITLE
Species generality bug fixes

### DIFF
--- a/R/01-data-interviews-one.R
+++ b/R/01-data-interviews-one.R
@@ -11,6 +11,8 @@
 prepare_interviews_one = function(input_file, include_salmon, include_nonsalmon, include_village, include_goals) {
 
   ### ERROR CHECKS FOR SPECIES ###
+
+  # small function to ensure acceptable values supplied
   check_spp_args = function(include, accepted, label) {
     has_all = any(include == "all")
     has_none = any(include == "none")
@@ -24,16 +26,24 @@ prepare_interviews_one = function(input_file, include_salmon, include_nonsalmon,
       paste0("if ", label, " includes 'none', it cannot include other selections") |>
         stop()
     }
-    if (!has_all & !has_none & !any(include %in% accepted)) {
+    if (!all(include %in% c("none", "all", accepted))) {
       paste0(label, " must be one of 'all', 'none', or any combination of ", knitr::combine_words(accepted, and = " or ", before = "'")) |>
         stop()
     }
   }
 
+  # which species names are accepted for salmon/nonsalmon?
   accepted_salmon = species_names$species[species_names$is_salmon]
-  check_spp_args(include_salmon, accepted_salmon, "include_salmon")
   accepted_nonsalmon = species_names$species[!species_names$is_salmon]
+
+  # check the validity of supplied argument values
+  check_spp_args(include_salmon, accepted_salmon, "include_salmon")
   check_spp_args(include_nonsalmon, accepted_nonsalmon, "include_nonsalmon")
+
+  # if both salmon and nonsalmon are set to 'none', return error
+  if (all(include_salmon == "none") & all(include_nonsalmon == "none")) {
+    stop ("one of include_salmon or include_nonsalmon must not be 'none'")
+  }
 
   ### STEP 0: load the input data file & format column names
   dat_in = suppressWarnings(read.csv(input_file, stringsAsFactors = FALSE))

--- a/R/01-data-interviews.R
+++ b/R/01-data-interviews.R
@@ -76,13 +76,16 @@ prepare_interviews = function(input_files, include_salmon = "all", include_nonsa
   }
 
   # perform checks for if the average catch per trip is an outlier
-  cpt_outliers = is_catch_per_trip_outlier(interview_data)
-  if (any(cpt_outliers)) {
-    outlier_cpt_notes[cpt_outliers] = "Catch per trip highly influential, catch rate rate, soak time, and net length deemed unsuitable for average"
-    interview_data$suit_cr_reliable[cpt_outliers] = FALSE
-    interview_data$suit_avg_soak[cpt_outliers] = FALSE
-    interview_data$suit_avg_net[cpt_outliers] = FALSE
-    warning("\n", sum(cpt_outliers), " interview(s) had a large influence on the average catch per trip.\nFor these records, the catch rate info has been deemed unreliable,\nand the soak time and net length will not be used in the average.")
+  # only perform for salmon
+  if (!("none" %in% include_salmon)) {
+    cpt_outliers = is_catch_per_trip_outlier(interview_data)
+    if (any(cpt_outliers)) {
+      outlier_cpt_notes[cpt_outliers] = "Catch per trip highly influential, catch rate rate, soak time, and net length deemed unsuitable for average"
+      interview_data$suit_cr_reliable[cpt_outliers] = FALSE
+      interview_data$suit_avg_soak[cpt_outliers] = FALSE
+      interview_data$suit_avg_net[cpt_outliers] = FALSE
+      warning("\n", sum(cpt_outliers), " interview(s) had a large influence on the average catch per trip.\nFor these records, the catch rate info has been deemed unreliable,\nand the soak time and net length will not be used in the average.")
+    }
   }
 
   # extract notes on suitability

--- a/R/02-est-catch-per-trip.R
+++ b/R/02-est-catch-per-trip.R
@@ -5,15 +5,17 @@
 #'
 #' @inheritParams estimate_harvest
 #' @param central_fn Function; used to calculate central tendency
-#' @param nonsalmon Logical; should estimates be returned for whitefish and sheefish rather than for Chinook, chum, and sockeye salmon?
+#' @param nonsalmon Logical; should estimates be returned non-salmon species rather than salmon species?
 
 estimate_catch_per_trip = function(interview_data, gear, randomize = FALSE, central_fn = getOption("central_fn"), nonsalmon = FALSE) {
 
   # set the species to keep
   if (!nonsalmon) {
-    keep_spp = c("chinook", "chum", "sockeye")
+    keep_spp = species_names$species[species_names$is_salmon]
+    keep_spp = keep_spp[keep_spp %in% colnames(interview_data)]
   } else {
-    keep_spp = c("sheefish", "whitefish")
+    keep_spp = species_names$species[!species_names$is_salmon]
+    keep_spp = keep_spp[keep_spp %in% colnames(interview_data)]
   }
 
   # subset only the data for this gear
@@ -31,7 +33,8 @@ estimate_catch_per_trip = function(interview_data, gear, randomize = FALSE, cent
   net_length = as.numeric(interview_data$net_length)
 
   # extract the catches
-  catches = interview_data[,keep_spp]
+  catches = as.matrix(interview_data[,keep_spp])
+  colnames(catches) = keep_spp
 
   # determine which are suitable for calculating reliable catch rates
   suitable_catch_rate = interview_data[,"suit_cr_reliable"] & interview_data[,"suit_cr_info"]
@@ -59,10 +62,12 @@ estimate_catch_per_trip = function(interview_data, gear, randomize = FALSE, cent
     if (sum(suitable_catch_rate) == 1) {
       out = sapply(catch_rates[suitable_catch_rate,], central_fn, na.rm = TRUE) * central_fn(net_length[suitable_avg_net], na.rm = TRUE) * central_fn(soak_hrs[suitable_avg_soak], na.rm = TRUE)
     } else {
-      out = apply(catch_rates[suitable_catch_rate,], 2, central_fn, na.rm = TRUE) * central_fn(net_length[suitable_avg_net], na.rm = TRUE) * central_fn(soak_hrs[suitable_avg_soak], na.rm = TRUE)
+      out = apply(as.matrix(catch_rates[suitable_catch_rate,]), 2, central_fn, na.rm = TRUE) * central_fn(net_length[suitable_avg_net], na.rm = TRUE) * central_fn(soak_hrs[suitable_avg_soak], na.rm = TRUE)
     }
   }
 
+  # format final output
+  names(out) = keep_spp
   # return the output
   return(out)
 }

--- a/R/02-est-catch-per-trip.R
+++ b/R/02-est-catch-per-trip.R
@@ -68,6 +68,8 @@ estimate_catch_per_trip = function(interview_data, gear, randomize = FALSE, cent
 
   # format final output
   names(out) = keep_spp
+  out[out == "NaN"] = 0  # occurs if all records for a species were NA
+
   # return the output
   return(out)
 }

--- a/man/estimate_catch_per_trip.Rd
+++ b/man/estimate_catch_per_trip.Rd
@@ -25,7 +25,7 @@ estimate_catch_per_trip(
 
 \item{central_fn}{Function; used to calculate central tendency}
 
-\item{nonsalmon}{Logical; should estimates be returned for whitefish and sheefish rather than for Chinook, chum, and sockeye salmon?}
+\item{nonsalmon}{Logical; should estimates be returned non-salmon species rather than salmon species?}
 }
 \description{
 Calculates the expected salmon catch by species for the average trip


### PR DESCRIPTION
Several bugs were introduced in the last PR (#197). The two main ones were:

* What was referred to as `species_names$species` was stored as `species_names$spp`
* `KuskoHarvEst:::estimate_catch_per_trip()` is called by `prepare_interviews()`, and previously did not account for fewer than all species being returned.

Both of these were returning errors that were very difficult to track down and were an unnecessary road bump.

I have verified now that the updated versions of `prepare_interviews_one()` and `prepare_interviews()` both work on all data sets included in 'KuskoHarvData' (check for generality) with a wide variety of combinations of the `include_salmon` and `include_nonsalmon` arguments, so I'm confident merging this PR and considering the data preparation portion of #178 complete.