### PR TITLE
Handle invalid gears

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: KuskoHarvEst
 Title: Tools for Producing In-season Estimates of Salmon Harvest and Effort Occurring in Short-Duration Subsistence Harvest Opportunities in the Lower Kuskokwim River
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: 
     person(given = "Ben",
            family = "Staton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # *NEWS*
 
+# KuskoHarvEst 1.2.3 (2023-09-14)
+
+* Added a new QA/QC check/data discarding rule: if the gear type returned is not valid (i.e., one of `drift` or `set` after removing case sensitivity, all spaces, and the presence of `net`), then it will be discarded by `KuskoHarvEst::prepare_interviews()` and a warning will be returned. The documentation on the data preparation tool has been updated to reflect this new warning type that can be returned.
+
 # KuskoHarvEst 1.2.2 (2023-07-08)
 
 ## Internal (Not User-Facing)

--- a/R/01-data-interviews-one.R
+++ b/R/01-data-interviews-one.R
@@ -87,7 +87,7 @@ prepare_interviews_one = function(input_file, include_salmon, include_nonsalmon,
   if (nrow(dat_out) == 0) return(NULL)
 
   ### STEP 3: handle the gear (net) type
-  gear_entered = stringr::str_remove(dat_in$gear, " ")
+  gear_entered = stringr::str_remove_all(dat_in$gear, " ")
   gear_standard = tolower(gear_entered) # make lowercase
   gear_standard = stringr::str_remove(gear_standard, "net")
   dat_out$gear = gear_standard

--- a/R/01-data-interviews.R
+++ b/R/01-data-interviews.R
@@ -39,6 +39,15 @@ prepare_interviews = function(input_files, include_salmon = "all", include_nonsa
     warning("\n", sum(no_gear), " interview(s) had missing gear type information.\nThese records have been discarded since they\ncannot be used for anything.")
   }
 
+  # discard any trips with invalid gear types
+  valid_gears = c("drift", "set")
+  if (!all(interview_data$gear %in% valid_gears)) {
+    bad_gears = interview_data$gear[!interview_data$gear %in% valid_gears]
+    n_bad_gears = length(bad_gears)
+    interview_data = interview_data[interview_data$gear %in% valid_gears,]
+    warning("\n", n_bad_gears, " interview(s) had invalid gear types (", knitr::combine_words(unique(bad_gears), before = "'"), ").\nThese records have been discarded since they\ncannot be used for anything.")
+  }
+
   # perform suitability checks and combine logical flags with the data
   tasks = c("effort", "catch_rate_info", "catch_rate_info_reliable", "avg_soak", "avg_net_length")
   suitable = sapply(tasks, suitable_for, interview_data = interview_data)

--- a/inst/rstudio/templates/04-docs/00-general.html
+++ b/inst/rstudio/templates/04-docs/00-general.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>General Instructions</title>
@@ -351,8 +351,8 @@ display: none;
 
 <h1 class="title toc-ignore"><strong>General Instructions</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 

--- a/inst/rstudio/templates/04-docs/01-raw-data.html
+++ b/inst/rstudio/templates/04-docs/01-raw-data.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>Raw Data File Format</title>
@@ -1380,8 +1380,8 @@ display: none;
 
 <h1 class="title toc-ignore"><strong>Raw Data File Format</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 

--- a/inst/rstudio/templates/04-docs/02-meta-data-tool.html
+++ b/inst/rstudio/templates/04-docs/02-meta-data-tool.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>How to Use: Meta-Data Tool</title>
@@ -352,8 +352,8 @@ display: none;
 <h1 class="title toc-ignore"><strong>How to Use: Meta-Data
 Tool</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 

--- a/inst/rstudio/templates/04-docs/03-interview-flight-data-tool.Rmd
+++ b/inst/rstudio/templates/04-docs/03-interview-flight-data-tool.Rmd
@@ -127,7 +127,13 @@ These messages may include:
     cat("Warning: X interview(s) had missing gear type information.\nThese records have been discarded since they\ncannot be used for anything.")
     ```
 
-* **Invalid stratum values**: The stratum columns must contain one of these values: `A`, `B`, `C`, `D1`, or `NA`. If another stratum value is found in the data, the corresponding records will be discarded and this warning will be returned:
+* **Invalid gear type**: if a record has an invalid gear type (i.e., something not containing the text `"drift"` or `"set"`, non-case sensitive, can include `"net"`, can include spaces), then it will be discarded entirely from the data set, and this warning will be returned:
+
+    ```{r, comment = NA}
+    cat("Warning: X interviews(s) had invalid gear types ([invalid values here])\nThese records have been discarded since they \ncannot be used for anything.")
+    ```
+
+* **Invalid stratum values**: The stratum columns must contain one of these values: `A`, `B`, `C`, `D1`, `D2`, or `NA`. If another stratum value is found in the data, the corresponding records will be discarded and this warning will be returned:
 
     ```{r, comment = NA}
     cat("Warning: There were X records with invalid stratum values: [invalid values here]\nThey have been discarded.")

--- a/inst/rstudio/templates/04-docs/03-interview-flight-data-tool.html
+++ b/inst/rstudio/templates/04-docs/03-interview-flight-data-tool.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>How to Use: Interview/Flight Data Tool</title>
@@ -352,8 +352,8 @@ display: none;
 <h1 class="title toc-ignore"><strong>How to Use: Interview/Flight Data
 Tool</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 
@@ -469,11 +469,19 @@ this warning will be returned:</p>
 <pre><code>Warning: X interview(s) had missing gear type information.
 These records have been discarded since they
 cannot be used for anything.</code></pre></li>
+<li><p><strong>Invalid gear type</strong>: if a record has an invalid
+gear type (i.e., something not containing the text <code>&quot;drift&quot;</code>
+or <code>&quot;set&quot;</code>, non-case sensitive, can include
+<code>&quot;net&quot;</code>, can include spaces), then it will be discarded
+entirely from the data set, and this warning will be returned:</p>
+<pre><code>Warning: X interviews(s) had invalid gear types ([invalid values here])
+These records have been discarded since they 
+cannot be used for anything.</code></pre></li>
 <li><p><strong>Invalid stratum values</strong>: The stratum columns must
 contain one of these values: <code>A</code>, <code>B</code>,
-<code>C</code>, <code>D1</code>, or <code>NA</code>. If another stratum
-value is found in the data, the corresponding records will be discarded
-and this warning will be returned:</p>
+<code>C</code>, <code>D1</code>, <code>D2</code>, or <code>NA</code>. If
+another stratum value is found in the data, the corresponding records
+will be discarded and this warning will be returned:</p>
 <pre><code>Warning: There were X records with invalid stratum values: [invalid values here]
 They have been discarded.</code></pre></li>
 <li><p><strong>Highly influential records</strong>: if a record has a

--- a/inst/rstudio/templates/04-docs/04-report-builder-tool.html
+++ b/inst/rstudio/templates/04-docs/04-report-builder-tool.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>How to Use: Report Builder Tool</title>
@@ -352,8 +352,8 @@ display: none;
 <h1 class="title toc-ignore"><strong>How to Use: Report Builder
 Tool</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 

--- a/inst/rstudio/templates/04-docs/05-code-overview.html
+++ b/inst/rstudio/templates/04-docs/05-code-overview.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>Code Overview</title>
@@ -1486,8 +1486,8 @@ border-radius: 0px;
 
 <h1 class="title toc-ignore"><strong>Code Overview</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 
@@ -1534,8 +1534,8 @@ file paths/names of these files:</p>
 <p>Note that three files store interview data and one stores flight
 counts.</p>
 <pre class="r"><code>basename(data_files)</code></pre>
-<pre><code>## [1] &quot;BBH_2020_06_12_EXAMPLE_ONLY.csv&quot;           &quot;CBM_2020_06_12_EXAMPLE_ONLY.csv&quot;          
-## [3] &quot;FC_2020_06_12_EXAMPLE_ONLY.csv&quot;            &quot;Flight_counts_2020_06_12_EXAMPLE_ONLY.csv&quot;</code></pre>
+<pre><code>## [1] &quot;BBH_2020_06_12_EXAMPLE_ONLY.csv&quot;           &quot;CBM_2020_06_12_EXAMPLE_ONLY.csv&quot;           &quot;FC_2020_06_12_EXAMPLE_ONLY.csv&quot;           
+## [4] &quot;Flight_counts_2020_06_12_EXAMPLE_ONLY.csv&quot;</code></pre>
 <p>Determine which files are used for which purpose:</p>
 <pre class="r"><code>flight_file = data_files[stringr::str_detect(data_files, &quot;Flight_counts&quot;)]
 interview_files = data_files[!stringr::str_detect(data_files, &quot;Flight_counts&quot;)]</code></pre>
@@ -1576,69 +1576,48 @@ this function.</p>
 <p>The output object stores interviews as rows and variables as columns
 just as in the raw data files, but again, it is now in a standardized
 and combined format. Here are the first 20 rows:</p>
-<pre><code>##    source stratum  gear net_length mesh_size          trip_start            trip_end trip_duration
-## 1     BBH       C drift        150     6.000 2020-06-12 06:00:00 2020-06-12 17:35:00    11H 35M 0S
-## 2     BBH       C drift        150     6.000 2020-06-12 05:30:00 2020-06-12 18:04:00    12H 34M 0S
-## 3     BBH       C drift        100     5.500 2020-06-12 06:00:00 2020-06-12 16:07:00     10H 7M 0S
-## 4     BBH       C drift        140     5.875 2020-06-12 06:00:00 2020-06-12 17:42:00    11H 42M 0S
-## 5     BBH       C   set         60     6.000 2020-06-12 06:00:00 2020-06-12 18:45:00    12H 45M 0S
-## 6     BBH       C   set         60     5.875 2020-06-12 05:30:00 2020-06-12 18:00:00    12H 30M 0S
-## 7     BBH       C drift         60     4.000 2020-06-12 06:00:00 2020-06-12 17:18:00    11H 18M 0S
-## 8     BBH       C drift        150     5.250 2020-06-12 06:00:00 2020-06-12 18:32:00    12H 32M 0S
-## 9     BBH       C   set         60     6.000 2020-06-12 06:00:00 2020-06-12 16:00:00     10H 0M 0S
-## 10    BBH       B   set        150     5.750 2020-06-12 08:00:00 2020-06-12 16:30:00     8H 30M 0S
-## 11    BBH       C drift        150     5.500 2020-06-12 06:00:00 2020-06-12 18:04:00     12H 4M 0S
-## 12    BBH       B drift        150     6.000 2020-06-12 06:00:00 2020-06-12 12:12:00     6H 12M 0S
-## 13    BBH       C drift        150     6.000 2020-06-12 12:00:00 2020-06-12 17:46:00     5H 46M 0S
-## 14    BBH       B drift         60     6.000 2020-06-12 08:00:00 2020-06-12 15:37:00     7H 37M 0S
-## 15    BBH       C   set         60     5.875 2020-06-12 06:00:00 2020-06-12 11:45:00     5H 45M 0S
-## 16    BBH       B drift        140     5.500 2020-06-12 06:25:00 2020-06-12 17:15:00    10H 50M 0S
-## 17    BBH       B drift         60     6.000 2020-06-12 07:30:00 2020-06-12 15:37:00      8H 7M 0S
-## 18    BBH       B drift        150     5.625 2020-06-12 09:00:00 2020-06-12 16:15:00     7H 15M 0S
-## 19    BBH       C drift        150     5.750 2020-06-12 13:30:00 2020-06-12 18:01:00     4H 31M 0S
-## 20    BBH       C drift        100     6.000 2020-06-12 13:00:00 2020-06-12 18:14:00     5H 14M 0S
-##    soak_duration chinook chum sockeye coho suit_effort suit_cr_info suit_cr_reliable suit_avg_soak
-## 1     11H 35M 0S      17    2       0   NA        TRUE         TRUE             TRUE          TRUE
-## 2     12H 34M 0S       1    1       1   NA        TRUE         TRUE             TRUE          TRUE
-## 3      10H 7M 0S       2    0       3   NA        TRUE         TRUE             TRUE          TRUE
-## 4     11H 42M 0S       0    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 5     12H 45M 0S       8    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 6     12H 30M 0S       6    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 7     11H 18M 0S       3    2       0   NA        TRUE         TRUE             TRUE          TRUE
-## 8      10H 0M 0S       8    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 9      10H 0M 0S       1    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 10     8H 30M 0S       3    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 11     6H 45M 0S      10    1       4   NA        TRUE         TRUE             TRUE          TRUE
-## 12      6H 0M 0S       6    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 13     5H 46M 0S       0    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 14     5H 50M 0S       1    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 15     5H 30M 0S       4    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 16     5H 25M 0S      10    1       2   NA        TRUE         TRUE             TRUE          TRUE
-## 17      5H 0M 0S       4    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 18      5H 0M 0S       1    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 19     4H 31M 0S       4    0       0   NA        TRUE         TRUE             TRUE          TRUE
-## 20      5H 0M 0S       3    0       0   NA        TRUE         TRUE             TRUE          TRUE
-##    suit_avg_net                                                                note
-## 1          TRUE                                                                &lt;NA&gt;
-## 2          TRUE                                                                &lt;NA&gt;
-## 3          TRUE                                                                &lt;NA&gt;
-## 4          TRUE                                                                &lt;NA&gt;
-## 5          TRUE                                                                &lt;NA&gt;
-## 6          TRUE                                                                &lt;NA&gt;
-## 7          TRUE Long soak duration (12H 0M 0S) edited to trip duration (11H 18M 0S)
-## 8          TRUE                                                                &lt;NA&gt;
-## 9          TRUE                                                                &lt;NA&gt;
-## 10         TRUE                                                                &lt;NA&gt;
-## 11         TRUE                                                                &lt;NA&gt;
-## 12         TRUE                                                                &lt;NA&gt;
-## 13         TRUE   Long soak duration (6H 0M 0S) edited to trip duration (5H 46M 0S)
-## 14         TRUE                                                                &lt;NA&gt;
-## 15         TRUE                                                                &lt;NA&gt;
-## 16         TRUE                                                                &lt;NA&gt;
-## 17         TRUE                                                                &lt;NA&gt;
-## 18         TRUE                                                                &lt;NA&gt;
-## 19         TRUE   Long soak duration (5H 0M 0S) edited to trip duration (4H 31M 0S)
-## 20         TRUE                                                                &lt;NA&gt;</code></pre>
+<pre><code>##    source stratum  gear net_length mesh_size          trip_start            trip_end trip_duration soak_duration chinook chum sockeye coho suit_effort suit_cr_info
+## 1     BBH       C drift        150     6.000 2020-06-12 06:00:00 2020-06-12 17:35:00    11H 35M 0S    11H 35M 0S      17    2       0   NA        TRUE         TRUE
+## 2     BBH       C drift        150     6.000 2020-06-12 05:30:00 2020-06-12 18:04:00    12H 34M 0S    12H 34M 0S       1    1       1   NA        TRUE         TRUE
+## 3     BBH       C drift        100     5.500 2020-06-12 06:00:00 2020-06-12 16:07:00     10H 7M 0S     10H 7M 0S       2    0       3   NA        TRUE         TRUE
+## 4     BBH       C drift        140     5.875 2020-06-12 06:00:00 2020-06-12 17:42:00    11H 42M 0S    11H 42M 0S       0    0       0   NA        TRUE         TRUE
+## 5     BBH       C   set         60     6.000 2020-06-12 06:00:00 2020-06-12 18:45:00    12H 45M 0S    12H 45M 0S       8    0       0   NA        TRUE         TRUE
+## 6     BBH       C   set         60     5.875 2020-06-12 05:30:00 2020-06-12 18:00:00    12H 30M 0S    12H 30M 0S       6    0       0   NA        TRUE         TRUE
+## 7     BBH       C drift         60     4.000 2020-06-12 06:00:00 2020-06-12 17:18:00    11H 18M 0S    11H 18M 0S       3    2       0   NA        TRUE         TRUE
+## 8     BBH       C drift        150     5.250 2020-06-12 06:00:00 2020-06-12 18:32:00    12H 32M 0S     10H 0M 0S       8    0       0   NA        TRUE         TRUE
+## 9     BBH       C   set         60     6.000 2020-06-12 06:00:00 2020-06-12 16:00:00     10H 0M 0S     10H 0M 0S       1    0       0   NA        TRUE         TRUE
+## 10    BBH       B   set        150     5.750 2020-06-12 08:00:00 2020-06-12 16:30:00     8H 30M 0S     8H 30M 0S       3    0       0   NA        TRUE         TRUE
+## 11    BBH       C drift        150     5.500 2020-06-12 06:00:00 2020-06-12 18:04:00     12H 4M 0S     6H 45M 0S      10    1       4   NA        TRUE         TRUE
+## 12    BBH       B drift        150     6.000 2020-06-12 06:00:00 2020-06-12 12:12:00     6H 12M 0S      6H 0M 0S       6    0       0   NA        TRUE         TRUE
+## 13    BBH       C drift        150     6.000 2020-06-12 12:00:00 2020-06-12 17:46:00     5H 46M 0S     5H 46M 0S       0    0       0   NA        TRUE         TRUE
+## 14    BBH       B drift         60     6.000 2020-06-12 08:00:00 2020-06-12 15:37:00     7H 37M 0S     5H 50M 0S       1    0       0   NA        TRUE         TRUE
+## 15    BBH       C   set         60     5.875 2020-06-12 06:00:00 2020-06-12 11:45:00     5H 45M 0S     5H 30M 0S       4    0       0   NA        TRUE         TRUE
+## 16    BBH       B drift        140     5.500 2020-06-12 06:25:00 2020-06-12 17:15:00    10H 50M 0S     5H 25M 0S      10    1       2   NA        TRUE         TRUE
+## 17    BBH       B drift         60     6.000 2020-06-12 07:30:00 2020-06-12 15:37:00      8H 7M 0S      5H 0M 0S       4    0       0   NA        TRUE         TRUE
+## 18    BBH       B drift        150     5.625 2020-06-12 09:00:00 2020-06-12 16:15:00     7H 15M 0S      5H 0M 0S       1    0       0   NA        TRUE         TRUE
+## 19    BBH       C drift        150     5.750 2020-06-12 13:30:00 2020-06-12 18:01:00     4H 31M 0S     4H 31M 0S       4    0       0   NA        TRUE         TRUE
+## 20    BBH       C drift        100     6.000 2020-06-12 13:00:00 2020-06-12 18:14:00     5H 14M 0S      5H 0M 0S       3    0       0   NA        TRUE         TRUE
+##    suit_cr_reliable suit_avg_soak suit_avg_net                                                                note
+## 1              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 2              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 3              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 4              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 5              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 6              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 7              TRUE          TRUE         TRUE Long soak duration (12H 0M 0S) edited to trip duration (11H 18M 0S)
+## 8              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 9              TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 10             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 11             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 12             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 13             TRUE          TRUE         TRUE   Long soak duration (6H 0M 0S) edited to trip duration (5H 46M 0S)
+## 14             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 15             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 16             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 17             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 18             TRUE          TRUE         TRUE                                                                &lt;NA&gt;
+## 19             TRUE          TRUE         TRUE   Long soak duration (5H 0M 0S) edited to trip duration (4H 31M 0S)
+## 20             TRUE          TRUE         TRUE                                                                &lt;NA&gt;</code></pre>
 <p>The columns that start with <code>&quot;suit_&quot;</code> store a
 <code>TRUE</code> if that object is suitable for a purpose and
 <code>FALSE</code> if not and the <code>&quot;note&quot;</code> column stores some

--- a/inst/rstudio/templates/04-docs/06-data-checks.html
+++ b/inst/rstudio/templates/04-docs/06-data-checks.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>Automated Interview Data Checks</title>
@@ -1487,8 +1487,8 @@ border-radius: 0px;
 <h1 class="title toc-ignore"><strong>Automated Interview Data
 Checks</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 

--- a/inst/rstudio/templates/04-docs/07-final-report-content.html
+++ b/inst/rstudio/templates/04-docs/07-final-report-content.html
@@ -9,7 +9,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Package Version: 1.2.1" />
+<meta name="author" content="Package Version: 1.2.3" />
 
 
 <title>Creation of Final Report Content</title>
@@ -1487,8 +1487,8 @@ border-radius: 0px;
 <h1 class="title toc-ignore"><strong>Creation of Final Report
 Content</strong></h1>
 <h3 class="subtitle"><em>KuskoHarvEst Documentation</em></h3>
-<h4 class="author">Package Version: 1.2.1</h4>
-<h4 class="date">Last Updated: 6/6/2023</h4>
+<h4 class="author">Package Version: 1.2.3</h4>
+<h4 class="date">Last Updated: 9/14/2023</h4>
 
 </div>
 


### PR DESCRIPTION
This PR closes #228 by introducing more standardized checks for gear types early in data preparation.

Specifically, `prepare_interviews()`now:

* Removes **all** spaces from the gear variable
* Retains only gear types matching `"drift"` or `"set"` after dropping the case and removing `"net"`
* If any are found that do not match these, a warning with the invalid gear types and number of offenses is returned.

The documentation on flight and data preparation tool was also updated to indicate this warning may be returned.