### PR TITLE
Fix remote depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package contains two main types of functionality to facilitate
     First, there are "core" functions that handle data processing and estimation tasks. However, many potential users
     of this package are not R programmers, and so the second type of functionality is to enable interactive and automated
     creation of estimates and reports. The intent is to place the emphasis of the analyst on the raw data files
-    rather than on the intracacies of estimation and automated reporting. 
+    rather than on the intricacies of estimation and automated reporting. 
 License: use_mit_license()
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,7 @@ Imports:
     tinytex,
     latex2exp,
     yaml,
-    settings
-remotes: bstaton1/KuskoHarvUtils
+    settings,
+    KuskoHarvUtils
+Remotes: 
+    bstaton1/KuskoHarvUtils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: KuskoHarvEst
 Title: Tools for Producing In-season Estimates of Salmon Harvest and Effort Occurring in Short-Duration Subsistence Harvest Opportunities in the Lower Kuskokwim River
-Version: 1.2.4
+Version: 1.2.5
 Authors@R: 
     person(given = "Ben",
            family = "Staton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # *NEWS*
 
+# KuskoHarvEst 1.2.5 (2023-10-25)
+
+* Updated DESCRIPTION to ensure 'KuskoHarvUtils' is installed automatically upon installing 'KuskoHarvEst' ([#188](https://www.github.com/bstaton1/KuskoHarvEst/issues/188))
+* Fixed minor typos in README and DESCRIPTION files
+
 # KuskoHarvEst 1.2.4 (2023-09-15)
 
 * Updated code to produce post-season content. Changes were all small in nature -- the content produced and the workflow to do so are the same, but several changes were needed to accommodate the new output for coho and stratum D2.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Many additional R packages will be installed automatically.
 
 ```R
 install.packages("remotes")
-remotes::install_github("bstaton1/KuskoHarvUtils")
 remotes::install_github("bstaton1/KuskoHarvEst")
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ install.packages("remotes")
 remotes::install_github("bstaton1/KuskoHarvEst")
 ```
 
-### $\mathrm{\LaTeX}$ Distribution and Additional Packages
+### TeX Distribution and Additional Packages
 
 $\mathrm{\LaTeX}$ is a program that allows building PDF documents from code.
 'KuskoHarvEst' depends on '[tinytex](https://yihui.org/tinytex/)', which is an R package that installs a minimal distribution (<0.1GB in size) and allows you to install extensions as needed.


### PR DESCRIPTION
This PR will _finally and permanently_ close #188. My previous solution introduced in #220 was not a good solution, as users had to install 'KuskoHarvUtils' manually. Now this is handled automatically, as this [devtools vignette](https://devtools.r-lib.org/articles/dependencies.html) describes is possible.

This is now version 1.2.5, and the NEWS file was updated to reflect the improvement.

I will implement this change across all other 'KuskoHarv**' packages.