### PR TITLE
Fix summation bug surrounding `NA` values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: KuskoHarvEst
 Title: Tools for Producing In-season Estimates of Salmon Harvest and Effort Occurring in Short-Duration Subsistence Harvest Opportunities in the Lower Kuskokwim River
-Version: 1.2.6
+Version: 1.2.7
 Authors@R: 
     person(given = "Ben",
            family = "Staton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # *NEWS*
 
+# KuskoHarvEst 1.2.7 (2024-08-07)
+
+* Fixed bug: bootstrap iterations resulting in `NA` now correctly handled when calculating totals across gears; see issue [#236](https://www.github.com/bstaton1/KuskoHarvEst/issues/188) and pull request [#237](https://www.github.com/bstaton1/KuskoHarvEst/pull/237) for complete details.
+
 # KuskoHarvEst 1.2.6 (2024-07-14)
 
 * Updated package hexsticker

--- a/R/02-est-bootstrap.R
+++ b/R/02-est-bootstrap.R
@@ -63,18 +63,18 @@ combine_boot_out = function(boot_out_drift = NULL, boot_out_set = NULL) {
   id_vars = c("iter", "date", "gear", "stratum")
 
   # placeholder object for if no drift estimates
-  # duplicate the set net output and convert estimates to NA
+  # duplicate the set net output and convert estimates to 0
   if (no_drift) {
     boot_out_drift = boot_out_set
-    boot_out_drift[,!(colnames(boot_out_drift) %in% id_vars)] = NA
+    boot_out_drift[,!(colnames(boot_out_drift) %in% id_vars)] = 0
     boot_out_drift$gear = "drift"
   }
 
   # placeholder object for if no set estimates
-  # duplicate the drift net output and convert estimates to NA
+  # duplicate the drift net output and convert estimates to 0
   if (no_set) {
     boot_out_set = boot_out_drift
-    boot_out_set[,!(colnames(boot_out_set) %in% id_vars)] = NA
+    boot_out_set[,!(colnames(boot_out_set) %in% id_vars)] = 0
     boot_out_set$gear = "set"
   }
 
@@ -84,7 +84,7 @@ combine_boot_out = function(boot_out_drift = NULL, boot_out_set = NULL) {
   # obtain a total across gears
   boot_out_total = cbind(
     boot_out_drift[,id_vars],
-    sapply(spp, function(s) rowSums(cbind(boot_out_drift[,s], boot_out_set[,s]), na.rm = TRUE))
+    sapply(spp, function(s) rowSums(cbind(boot_out_drift[,s], boot_out_set[,s]), na.rm = FALSE))
   )
   boot_out_total$gear = "total"
 


### PR DESCRIPTION
This PR closes #236 with a simple fix.

Although I initially thought the impacts of this bug would be somewhat far-reaching, they are not for the following reasons.

* The bug was introduced in the 2023 season (likely as part of #194), so only impacts in-season and final report estimates in that year and so far in 2024.
* This bug only occurs when quality interview data for a stratum are exceedingly rare. Recently, this has only occurred during late-season openers.
* A comparison of the old and new calculation of the values populating Table 6 in Bechtol et al. ([2024](https://doi.org/10.5281/zenodo.12752044)) -- total harvest by opener, species, and stratum -- yields very similar results (see the [diff](https://www.diffchecker.com/RuwTyTet/), indicating that this was not a very consequential bug in the places it could have affected the output.
* This bug does not impact our work in either the manuscript projects `KuskoHarvEst-ms` or `KuskoHarvPred-ms`, since those report harvest from drift gillnets. This was confirmed by rebuilding the data sets contained in the 'KuskoHarvData' package.